### PR TITLE
fvwm: build with --enable-mandoc

### DIFF
--- a/srcpkgs/fvwm/template
+++ b/srcpkgs/fvwm/template
@@ -3,6 +3,7 @@ pkgname=fvwm
 version=2.6.9
 revision=1
 build_style=gnu-configure
+configure_args="--enable-mandoc"
 hostmakedepends="libxslt pkg-config python"
 makedepends="fribidi-devel libXcursor-devel libXft-devel libXinerama-devel
  libXpm-devel libXt-devel librsvg-devel perl readline-devel"


### PR DESCRIPTION
Generate fvwm.1 manpage that contains the majority of the documentation.